### PR TITLE
Updated init method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "enmap-rethink",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "dependencies": {
     "acorn": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enmap-rethink",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ class EnmapRethink {
 
     if (!options.name) throw new Error('Must provide options.name');
     this.name = options.name;
+    this.dbName = options.dbName || 'enmap';
     this.validateName();
 
     this.port = options.port || 28015;
@@ -29,10 +30,10 @@ class EnmapRethink {
   async init(enmap) {
     this.connection = await r({ servers: [{ host: this.host, port: this.port }] });
     const dbs = await this.connection.dbList().run();
-    if (!dbs.includes('enmap')) {
-      await this.connection.dbCreate('enmap');
+    if (!dbs.includes(this.dbName)) {
+      await this.connection.dbCreate(this.dbName);
     }
-    this.db = this.connection.db('enmap');
+    this.db = this.connection.db(this.dbName);
     const tables = await this.db.tableList();
     if (tables.includes(this.name)) {
       const data = await this.db.table(this.name).run();

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ class EnmapRethink {
     }
     this.db = this.connection.db(this.dbName);
     const tables = await this.db.tableList();
+    let iData;
     if (tables.includes(this.name)) {
       const data = await this.db.table(this.name).run();
       this.table = this.db.table(this.name);


### PR DESCRIPTION
Changed `init` method to allow naming of databases, if undefined or null, should create an `enmap` database to create backwards compatibility with existing projects.

change `const settings = new Enmap({provider: new EnmapRethink({name: "settings"})});` to `const settings = new Enmap({ provider: new EnmapRethink({ dbName: "new database", name: "settings" }) });` when defining a database,